### PR TITLE
Ruote2.1

### DIFF
--- a/lib/ruote-amqp/participant.rb
+++ b/lib/ruote-amqp/participant.rb
@@ -196,10 +196,16 @@ module RuoteAMQP
     # this participant.
     #
     def encode_workitem( wi )
-
       wi.params['participant_options'] = @options
       wi.params['forget'] = @forget
 
+      # make sure the command and reply_queue given at create time are honoured
+      if !wi.params.has_key?('command') and @options.has_key?('command')
+        wi.params['command'] ||= @options['command']
+      end
+      if !wi.params.has_key?('reply_queue') and @options.has_key?('reply_queue')
+        wi.params['reply_queue'] = @options['reply_queue']
+      end
       Rufus::Json.encode( wi.to_h )
     end
   end

--- a/lib/ruote-amqp/participant.rb
+++ b/lib/ruote-amqp/participant.rb
@@ -125,6 +125,7 @@ module RuoteAMQP
       @options = {
         'queue' => nil,
         'forget' => false,
+        'reply_queue' => 'ruote_workitems'
       }.merge( options.inject( {} ) { |h, ( k, v )| h[k.to_s] = v; h } )
         #
         # the inject is here to make sure that all options have String keys


### PR DESCRIPTION
Hi,

The 2 commits here will set a default for the reply_queue that corresponds with that from RuoteAMQP::Receiver and they will allow the command to be specified at Participant create-time.

It seems highly unlikely that the reply_queue needs to be set inside the process definition, but things are still backwards compatible. Mainly because of command - because setting the command within the process definition might be valid, although a different command feels like a different participant to me...
