### PR TITLE
Convey remote backtrace if available in workitem

### DIFF
--- a/lib/ruote/amqp/receiver.rb
+++ b/lib/ruote/amqp/receiver.rb
@@ -153,6 +153,13 @@ module Ruote::Amqp
         else [ RemoteError, err.inspect ]
       end
 
+      if h['trace']
+        args << h.delete('trace')
+
+      elsif err['trace']
+        args << err['trace']
+      end
+
       super(h, *args)
     end
 


### PR DESCRIPTION
Depends on 
https://github.com/jmettraux/ruote/commit/b7eeff0d789bfe878b26e3139804744fcade864c

If the remote participant has set a trace in the workitem, add it to the error.
